### PR TITLE
Add support for ginkgo v2 cli

### DIFF
--- a/src/ginkgoJSONReport.ts
+++ b/src/ginkgoJSONReport.ts
@@ -1,0 +1,30 @@
+export interface JSONReportNodeLocation {
+    FileName: string
+    LineNumber: number    
+}
+
+export interface JSONSpecFailure {
+    Message: string
+    Location: JSONReportNodeLocation & {
+        FullStackTrace: string
+    }
+}
+
+export interface JSONSpecReport {
+    State: 'passed' | 'skipped' | 'failed'
+    // 'It', 'When', 'Describe' etc
+    LeafNodeType: string
+    // Label for the node (e.g. for It('something', func() { }) -> LeafNodeText == 'something')
+    LeafNodeText: string
+    LeafNodeLocation: JSONReportNodeLocation
+    ContainerHierarchyTexts: string[] | null
+    ContainerHierarchyLocations: JSONReportNodeLocation[] | null
+    Failure?: JSONSpecFailure
+}
+
+export interface JSONSuiteReport {
+    SuiteDescription: string
+    SpecReports: JSONSpecReport[]
+}
+
+export type JSONReport = JSONSuiteReport[];

--- a/src/ginkgoTestTreeDataProvider.ts
+++ b/src/ginkgoTestTreeDataProvider.ts
@@ -257,10 +257,13 @@ export class GinkgoTestTreeDataProvider implements vscode.TreeDataProvider<Ginkg
         const parentNode = graph.find(n => n.key === node.parent.key);
         if (parentNode) {
             if (parentNode.result === undefined) {
-                parentNode.result = node.result;
+                parentNode.result = node.result ? { ...node.result } : undefined;
             } else {
                 if (node.result) {
-                    parentNode.result.isPassed = parentNode.result.isPassed && node.result.isPassed;
+                    parentNode.result = {
+                        ...parentNode.result,
+                        isPassed: parentNode.result.isPassed && node.result.isPassed
+                    };
                 }
             }
         }

--- a/src/outliner.unit.test.ts
+++ b/src/outliner.unit.test.ts
@@ -12,7 +12,7 @@ const sampleOutput: string = `[{"name":"Describe","text":"NormalFixture","start"
 
 describe('outline.fromJSON', function () {
     it('should return an Outline with equivalent nested and flat representations', function () {
-        const got = outliner.fromJSON(sampleOutput);
+        const got = outliner.fromJSON(sampleOutput, 1);
 
         let i = 0;
         for (let n of got.nested) {
@@ -25,7 +25,7 @@ describe('outline.fromJSON', function () {
     });
 
     it('should return an Outline where every child node references its parent', function () {
-        const got = outliner.fromJSON(sampleOutput);
+        const got = outliner.fromJSON(sampleOutput, 1);
 
         for (let tn of got.nested) {
             for (let c of tn.nodes) {

--- a/src/util/ginkgoVersion.ts
+++ b/src/util/ginkgoVersion.ts
@@ -1,0 +1,25 @@
+import * as cp from 'child_process';
+
+export async function detectGinkgoMajorVersion(ginkgoPath: string): Promise<number> {
+  return new Promise<number>(async (resolve, reject) => {
+      try {
+          const tp = cp.spawn(ginkgoPath, ["version"], { shell: true });
+          let result = "";
+          tp.stdout.on('data', (chunk) => result += chunk.toString());
+          tp.on('close', code => {
+              if (code !== 0) {
+                  reject(new Error(`Failed to detect ginkgo version ${code}`));
+              }
+
+              const match = result.match(/([0-9]+)\.([0-9]+)\.([0-9]+)/);
+              if (match) {
+                  const majorVersion = parseInt(match[1], 10);
+                  resolve(!isNaN(majorVersion) ? majorVersion : 1);
+              }
+              resolve(1);
+          });
+      } catch (err) {
+          reject(err);
+      }
+  });
+}


### PR DESCRIPTION
This PR adds support for v2 of ginkgo (resolving issue #44).

1. For test run reports it relies on the output of `--json-report` instead of JUnit-like reports.2. 
2. When need it detects the version of ginkgo binary and behaves accordingly, preserving the previous behavior if version 1 was detected.

### Checklist

- [x] Ensure changes are being done following agreed and compliant design.
- [x] Coding follows style guidelines.
- [x] Code changes do not generate new warnings.
- [x] Dependencies are updated according to introduced changes.
- [ ] Tests created and/or modified and successfully passing.
- [ ] There are changes not related directly to the ticket.
