### PR TITLE
fix: recover "when" keyword injection

### DIFF
--- a/src/ginkgoOutliner.ts
+++ b/src/ginkgoOutliner.ts
@@ -84,7 +84,7 @@ export async function callGinkgoOutline(ginkgoPath: string, doc: vscode.TextDocu
 }
 
 function getNodeKey(node: GinkgoNode, ginkgoMajorVersion: number): string {
-    if (ginkgoMajorVersion < 2 && node.name.endsWith("When")) {
+    if (node.name.endsWith("When")) {
         return getNodeKey(node.parent, ginkgoMajorVersion) + " when " + node.text;
     }
     if (node.parent) {


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->

If applied, this commit will recover ginkgo 1.X version behaviour to the `--focus` command, where it injected `when` keyword if a `When` container is present. Sadly, this will mean if you're running ginkgo versions <=2.1.3, this plugin will stop working if you use `When` nodes. However, this plugin is currently not working if using ginkgo versions >= 2.1.4 with `When` nodes.

<!-- Why is this change being made? -->

This change is being made because for ginkgo version 2.1.4 onwards, `--focus` command uses the old `1.X` behaviour.

<!-- Provide links to any relevant tickets, URLs, or other resources (optional) -->

[Ginkgo 2.1.4 release](https://github.com/onsi/ginkgo/releases/tag/v2.1.4)
[Discussion about When behaviour](https://github.com/onsi/ginkgo/issues/1226)

### Checklist

- [X] Ensure changes are being done following agreed and compliant design.
- [X] Coding follows style guidelines.
- [X] Code changes do not generate new warnings.
- [X] Dependencies are updated according to introduced changes.
- [X] Tests created and/or modified and successfully passing.
- [X] There are changes not related directly to the ticket.
