### PR TITLE
Doc: specify that env variables are not expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
         "ginkgotestexplorer.ginkgoPath": {
           "type": "string",
           "default": "ginkgo",
-          "description": "Path to ginkgo executable."
+          "description": "Path to ginkgo executable. Environment variables are not expanded."
         },
         "ginkgotestexplorer.doubleClickThreshold": {
           "type": "number",


### PR DESCRIPTION
<!-- If applied, this commit will... -->
This commit documents that the env vars are not expanded in the value provided in ginkgotestexplorer.ginkgoPath configuration option.

<!-- Why is this change being made? -->
An error is encountered when ginkgotestexplorer.ginkgoPath contains an env var. The extension cannot be activated.


<!-- Provide links to any relevant tickets, URLs, or other resources (optional) -->
https://github.com/joselitofilho/ginkgoTestExplorer/issues/52


