### PR TITLE
Feat/support workspace folder variable

### DIFF
--- a/src/cachingOutliner.ts
+++ b/src/cachingOutliner.ts
@@ -3,7 +3,7 @@
 import * as vscode from 'vscode';
 import { constants } from './constants';
 import * as outliner from './ginkgoOutliner';
-import { affectsConfiguration, getConfiguration, outputChannel } from './ginkgoTestExplorer';
+import { affectsConfiguration, getConfiguration, outputChannel, replaceVscodeVariables } from './ginkgoTestExplorer';
 
 interface CacheValue {
     docVersion: number,
@@ -22,7 +22,8 @@ export class CachingOutliner {
         this.context.subscriptions.push({ dispose: () => { this.clear(); } });
         this.context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(evt => {
             if (affectsConfiguration(evt, 'ginkgoPath')) {
-                this.outliner.setGinkgoPath(getConfiguration().get('ginkgoPath', constants.defaultGinkgoPath));
+                let ginkgoPathConfig = getConfiguration().get('ginkgoPath', constants.defaultGinkgoPath);
+                this.outliner.setGinkgoPath(replaceVscodeVariables(ginkgoPathConfig));
                 this.setOutliner(this.outliner);
             }
             if (affectsConfiguration(evt, 'cacheTTL')) {

--- a/src/ginkgoTest.ts
+++ b/src/ginkgoTest.ts
@@ -8,7 +8,7 @@ import * as junit2json from 'junit2json';
 import { Commands } from './commands';
 import { TestResult } from './testResult';
 import { constants, ExecuteCommandsOn } from './constants';
-import { affectsConfiguration, getConfiguration, outputChannel } from './ginkgoTestExplorer';
+import { affectsConfiguration, getConfiguration, outputChannel, replaceVscodeVariables } from './ginkgoTestExplorer';
 import { parseEnvFile } from './util/env';
 import { resolvePath } from './util/fileSystem';
 import { detectGinkgoMajorVersion } from './util/ginkgoVersion';
@@ -37,7 +37,8 @@ export class GinkgoTest {
 
         this.context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(evt => {
             if (affectsConfiguration(evt, 'ginkgoPath')) {
-                this.setGinkgoPath(getConfiguration().get('ginkgoPath', constants.defaultGinkgoPath));
+                let ginkgoPathConfig = getConfiguration().get('ginkgoPath', constants.defaultGinkgoPath);
+                this.setGinkgoPath(replaceVscodeVariables(ginkgoPathConfig));
             }
             if (affectsConfiguration(evt, 'testEnvVars')) {
                 this.setTestEnvVars(getConfiguration().get('testEnvVars', constants.defaultTestEnvVars));

--- a/src/ginkgoTestExplorer.ts
+++ b/src/ginkgoTestExplorer.ts
@@ -15,6 +15,20 @@ export function getConfiguration(): vscode.WorkspaceConfiguration {
     return vscode.workspace.getConfiguration(constants.extensionName);
 }
 
+export function replaceVscodeVariables(configValue: string): string {
+    let workspaceFolder = undefined;
+    let uri = vscode.window.activeTextEditor?.document.uri;
+    if (uri) {
+        workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+    }
+
+    if (workspaceFolder) {
+        configValue = configValue.replace('${workspaceFolder}', workspaceFolder.uri.fsPath);
+    }
+
+    return configValue;
+}
+
 export function affectsConfiguration(evt: vscode.ConfigurationChangeEvent, name: string): boolean {
     return evt.affectsConfiguration(`${constants.extensionName}.${name}`);
 }


### PR DESCRIPTION
<!--

Hi, thanks for contributing!

Please make sure you read our CONTRIBUTING guide.

Please fill the fields above:

-->

<!-- If applied, this commit will... -->
This adds a new method that will replace the `${workspaceFolder}` variable in a string with the expanded value based on the workspace of the active text editor tab.
    
This change adds support for this replacement when processing the ginkgoPath configuration value.

<!-- Why is this change being made? -->
To support being able to reference a local version of ginkgo. I have multiple projects that may be using different versions of the tools, but they all fetch the necessary version into a path local to the `workspaceFolder` in vscode.

<!-- Provide links to any relevant tickets, URLs, or other resources (optional) -->
Note: I am not a strong typeScript person neither am I very familiar with the vscode API, so there may be better ways to do this.

Fixes #52 

### Checklist

- [ ] Ensure changes are being done following agreed and compliant design. *Note: I haven't talked to anyone about the design, so there was no prior agreement on this*
- [x] Coding follows style guidelines.
- [x] Code changes do not generate new warnings.
- [x] Dependencies are updated according to introduced changes.
- [x] Tests created and/or modified and successfully passing.
- [ ] There are changes not related directly to the ticket. *Note: I did have to make changes to some of the exception handling type checks to get local development to work, but those are not included here*
