### PR TITLE
Ignore non-test files to prevent excessive error popup

### DIFF
--- a/src/ginkgoTestTreeDataProvider.ts
+++ b/src/ginkgoTestTreeDataProvider.ts
@@ -141,6 +141,10 @@ export class GinkgoTestTreeDataProvider implements vscode.TreeDataProvider<Ginkg
             outputChannel.appendLine(`Did not populate outline view: document "${this.editor.document.uri}" language is not Go.`);
             return undefined;
         }
+        if (!this.editor.document.fileName.toLowerCase().endsWith("_test.go")) {
+            outputChannel.appendLine(`Did not populate outline view: document "${this.editor.document.uri}" does not end with '_test.go'.`);
+            return undefined;
+        }
         if (this._roots.length === 0) {
             try {
                 const outline = await this.outlineFromDoc(this.editor.document);


### PR DESCRIPTION
### If applied, this commit will...
Stop producing error popups when the file is not a Go test file.

### Why is this change being made?
It currently is very annoying to have an error popup in VScode when switching from a test file to a non-test file and having the Ginkgo explorer tab open. The popup also stays there forever.

Related to #40 